### PR TITLE
Change queue order, new elem will be append on left

### DIFF
--- a/signal_bot/backend/bot/chat_client/clients/signal_chatter.py
+++ b/signal_bot/backend/bot/chat_client/clients/signal_chatter.py
@@ -32,7 +32,7 @@ class SignalChatter(Chatter):
         self._send_data(data)
 
     def get_history(self, nb_messages: int = 10) -> list:
-        return self.queue.get_n_first(nb_messages)
+        return self.queue.get_n_last(nb_messages)
 
     def _get_last_message(self, message_end_marker=b"\n") -> str:
         data = self.cached_message

--- a/signal_bot/backend/commands/functions/openai.py
+++ b/signal_bot/backend/commands/functions/openai.py
@@ -35,7 +35,7 @@ def get_openai_prediction(prompt):
 def create_prompt_context(base_prompt=""):
     history = chatter.get_history(20)
     prompt_context = base_prompt
-    for message_dict in history:
+    for message_dict in history.reverse():
         message=message_dict["params"]["dataMessage"]["message"]
         user=message_dict["params"]["sourceNumber"]
         prompt_context += f"{user}: {message}\n"

--- a/signal_bot/backend/db/queue_storage.py
+++ b/signal_bot/backend/db/queue_storage.py
@@ -13,7 +13,7 @@ class QueueStorage(ABC):
         pass
 
     @abstractmethod
-    def get_n_first(self, nb_elem: int = 1) -> any:
+    def get_n_last(self, nb_elem: int = 1) -> any:
         pass
 
     @abstractmethod

--- a/signal_bot/backend/db/queue_storage_provider/deque_storage.py
+++ b/signal_bot/backend/db/queue_storage_provider/deque_storage.py
@@ -19,7 +19,7 @@ class DequeStorage(QueueStorage):
             res = None
         return res
 
-    def get_n_first(self, nb_elem: int = 1) -> any:
+    def get_n_last(self, nb_elem: int = 1) -> any:
         res = []
         for i in range(nb_elem):
             elem = self.get(i)
@@ -29,7 +29,7 @@ class DequeStorage(QueueStorage):
         return res
 
     def put(self, value: any) -> None:
-        self.queue.append(value)
+        self.queue.appendleft(value)
 
     def get_all(self) -> any:
         return list(self.queue)

--- a/signal_bot/backend/test/unit/db/test_queue_storage.py
+++ b/signal_bot/backend/test/unit/db/test_queue_storage.py
@@ -9,15 +9,15 @@ def test_queue_storage_maxlen(queue_storage):
     assert queue_storage.get() is None
     for i in range(5):
         assert queue_storage.put(i) is None
-    assert queue_storage.get_all() == [0, 1, 2, 3, 4]
+    assert queue_storage.get_all() == [4, 3, 2, 1, 0]
     assert queue_storage.put(5) is None
-    assert queue_storage.get_all() == [1, 2, 3, 4, 5]
+    assert queue_storage.get_all() == [5, 4, 3, 2, 1]
 
 def test_queue_storage_n_first(queue_storage):
     assert queue_storage.get() is None
     for i in range(5):
         assert queue_storage.put(i) is None
-    assert queue_storage.get_all() == [0, 1, 2, 3, 4]
-    assert queue_storage.get_n_first(3) == [0, 1, 2]
-    assert queue_storage.get_all() == [0, 1, 2, 3, 4]
-    assert queue_storage.get_n_first(10) == [0, 1, 2, 3, 4]
+    assert queue_storage.get_all() == [4, 3, 2, 1, 0]
+    assert queue_storage.get_n_last(3) == [4, 3, 2]
+    assert queue_storage.get_all() == [4, 3, 2, 1, 0]
+    assert queue_storage.get_n_last(10) == [4, 3, 2, 1, 0]


### PR DESCRIPTION
# Fix

History message was append to a list, meaning new message was added at the end of the queue. 

Change it so new message are append on left and have index 0